### PR TITLE
Add username lookup for user auth

### DIFF
--- a/api-eventos/config/db.js
+++ b/api-eventos/config/db.js
@@ -3,9 +3,18 @@ require('dotenv').config();
 
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY);
 
-// Supabase no requiere inicialización local, pero mantenemos la función para mantener compatibilidad
 async function initializeDatabase() {
-  return true;
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_KEY) {
+    console.warn('Supabase credentials are not set. Skipping database initialization.');
+    return;
+  }
+
+  try {
+    await supabase.from('users').select('id').limit(1);
+    console.log('Database initialized');
+  } catch (err) {
+    console.warn('Could not verify database connection:', err.message);
+  }
 }
 
 // USERS
@@ -32,9 +41,10 @@ async function findUserByUsername(username) {
   const { data, error } = await supabase
     .from('users')
     .select('*')
-    .eq('username', username);
+    .eq('username', username)
+    .single();
   if (error) throw error;
-  return data && data.length > 0 ? data[0] : null;
+  return data;
 }
 
 async function findUserById(id) {

--- a/api-eventos/config/db.js
+++ b/api-eventos/config/db.js
@@ -3,6 +3,11 @@ require('dotenv').config();
 
 const supabase = createClient(process.env.SUPABASE_URL, process.env.SUPABASE_KEY);
 
+// Supabase no requiere inicialización local, pero mantenemos la función para mantener compatibilidad
+async function initializeDatabase() {
+  return true;
+}
+
 // USERS
 async function createUser(user) {
   const { data, error } = await supabase
@@ -20,6 +25,16 @@ async function findUserByEmail(email) {
     .single();
   if (error) throw error;
   return data;
+}
+
+// Nueva función para buscar usuario por username
+async function findUserByUsername(username) {
+  const { data, error } = await supabase
+    .from('users')
+    .select('*')
+    .eq('username', username);
+  if (error) throw error;
+  return data && data.length > 0 ? data[0] : null;
 }
 
 async function findUserById(id) {
@@ -283,6 +298,7 @@ module.exports = {
   // Users
   createUser,
   findUserByEmail,
+  findUserByUsername,
   findUserById,
   // Events
   createEvent,
@@ -315,5 +331,6 @@ module.exports = {
   getLocationsByProvince,
   findLocationById,
   // Supabase client (por si lo necesitás para queries custom)
-  supabase
+  supabase,
+  initializeDatabase
 };

--- a/api-eventos/controllers/user.controller.js
+++ b/api-eventos/controllers/user.controller.js
@@ -1,4 +1,4 @@
-const { dbOperations } = require('../config/db');
+const dbOperations = require('../config/db');
 const bcrypt = require('bcryptjs');
 const jwt = require('jsonwebtoken');
 


### PR DESCRIPTION
## Summary
- query Supabase users by username with new helper
- import db helpers directly in user controller
- expose initializeDatabase stub to satisfy server startup

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm start` *(fails to contact Supabase: TypeError: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68ac49293af48329b153ac5c02cd3ed7