### PR TITLE
Include event tags in event responses

### DIFF
--- a/api-eventos/controllers/event.controller.js
+++ b/api-eventos/controllers/event.controller.js
@@ -18,6 +18,7 @@ exports.listEvents = async (req, res) => {
     const processedEvents = await Promise.all(events.map(async (event) => {
       const eventLocation = await dbOperations.findEventLocationById(event.id_event_location);
       const creatorUser = await dbOperations.findUserById(event.id_creator_user);
+      const tags = await dbOperations.getEventTags(event.id);
 
       return {
         id: event.id,
@@ -30,7 +31,7 @@ exports.listEvents = async (req, res) => {
         max_assistance: event.max_assistance,
         event_location: eventLocation,
         creator_user: creatorUser,
-        tags: [] // Por ahora sin tags
+        tags: tags
       };
     }));
 
@@ -52,12 +53,13 @@ exports.getEventDetail = async (req, res) => {
 
     const eventLocation = await dbOperations.findEventLocationById(event.id_event_location);
     const creatorUser = await dbOperations.findUserById(event.id_creator_user);
+    const tags = await dbOperations.getEventTags(event.id);
 
     const result = {
       ...event,
       event_location: eventLocation,
       creator_user: creatorUser,
-      tags: [] // Por ahora sin tags
+      tags: tags
     };
 
     res.status(200).json(result);

--- a/api-eventos/postman_collection.json
+++ b/api-eventos/postman_collection.json
@@ -82,6 +82,20 @@
       "item": [
         {
           "name": "Listar Eventos",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const data = pm.response.json();",
+                  "pm.test('Tags property is present', function () {",
+                  "    pm.expect(data.collection[0]).to.have.property('tags');",
+                  "    pm.expect(Array.isArray(data.collection[0].tags)).to.be.true;",
+                  "});"
+                ]
+              }
+            }
+          ],
           "request": {
             "method": "GET",
             "header": [],
@@ -158,6 +172,20 @@
         },
         {
           "name": "Detalle de Evento",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "const data = pm.response.json();",
+                  "pm.test('Tags property is present', function () {",
+                  "    pm.expect(data).to.have.property('tags');",
+                  "    pm.expect(Array.isArray(data.tags)).to.be.true;",
+                  "});"
+                ]
+              }
+            }
+          ],
           "request": {
             "method": "GET",
             "header": [],


### PR DESCRIPTION
## Summary
- Fetch event tags from database in list and detail controllers
- Include event tags in API responses
- Add Postman tests ensuring tags are returned

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac4df218f48329b56da304ed7737e1