### PR TITLE
Fix getEventLocations to return array

### DIFF
--- a/eventos-app/src/screens/CreateEventScreen.tsx
+++ b/eventos-app/src/screens/CreateEventScreen.tsx
@@ -70,13 +70,13 @@ const CreateEventScreen: React.FC<{ navigation: any }> = ({ navigation }) => {
   const loadInitialData = async () => {
     try {
       setLoadingData(true);
-      const [locationsData, tagsData, provincesData] = await Promise.all([
+      const [locations, tagsData, provincesData] = await Promise.all([
         eventLocationService.getEventLocations(),
         tagService.getTags(),
         provinceService.getProvinces(),
       ]);
-      
-      setEventLocations(locationsData);
+
+      setEventLocations(locations);
       setTags(tagsData);
       setProvinces(provincesData);
     } catch (error) {

--- a/eventos-app/src/services/api.ts
+++ b/eventos-app/src/services/api.ts
@@ -104,8 +104,8 @@ export const eventService = {
 // Event Location Services
 export const eventLocationService = {
   getEventLocations: async (): Promise<EventLocation[]> => {
-    const response = await api.get<EventLocation[]>('/event-location');
-    return response.data;
+    const response = await api.get<{ collection: EventLocation[] }>('/event-location');
+    return response.data.collection;
   },
 
   getEventLocationById: async (id: number): Promise<EventLocation> => {


### PR DESCRIPTION
## Summary
- parse event location collection response and return array
- update CreateEventScreen to handle new array result

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68ac4eea9a548329ab04189efbd0eca1