### PR TITLE
Update tag and location API handling

### DIFF
--- a/eventos-app/src/screens/CreateEventScreen.tsx
+++ b/eventos-app/src/screens/CreateEventScreen.tsx
@@ -70,14 +70,14 @@ const CreateEventScreen: React.FC<{ navigation: any }> = ({ navigation }) => {
   const loadInitialData = async () => {
     try {
       setLoadingData(true);
-      const [locations, tagsData, provincesData] = await Promise.all([
+      const [eventLocationsData, tags, provincesData] = await Promise.all([
         eventLocationService.getEventLocations(),
         tagService.getTags(),
         provinceService.getProvinces(),
       ]);
 
-      setEventLocations(locations);
-      setTags(tagsData);
+      setEventLocations(eventLocationsData);
+      setTags(tags);
       setProvinces(provincesData);
     } catch (error) {
       console.error('Error loading initial data:', error);
@@ -89,7 +89,8 @@ const CreateEventScreen: React.FC<{ navigation: any }> = ({ navigation }) => {
 
   const loadLocationsByProvince = async (provinceId: number) => {
     try {
-      const locationsData = await locationService.getLocationsByProvince(provinceId);
+      const { locations: locationsData } =
+        await locationService.getLocationsByProvince(provinceId);
       setLocations(locationsData);
     } catch (error) {
       console.error('Error loading locations:', error);

--- a/eventos-app/src/services/api.ts
+++ b/eventos-app/src/services/api.ts
@@ -138,8 +138,10 @@ export const eventLocationService = {
 // Tag Services
 export const tagService = {
   getTags: async (): Promise<Tag[]> => {
-    const response = await api.get<Tag[]>('/tags');
-    return response.data;
+    const response = await api.get<{ success: boolean; tags: Tag[] }>(
+      '/tags'
+    );
+    return response.data.tags;
   },
 };
 
@@ -153,13 +155,23 @@ export const provinceService = {
 
 // Location Services
 export const locationService = {
-  getLocations: async (): Promise<Location[]> => {
-    const response = await api.get<Location[]>('/locations');
+  getLocations: async (
+    provinceId: number
+  ): Promise<{ success: boolean; locations: Location[] }> => {
+    const response = await api.get<{
+      success: boolean;
+      locations: Location[];
+    }>(`/locations/province/${provinceId}`);
     return response.data;
   },
 
-  getLocationsByProvince: async (provinceId: number): Promise<Location[]> => {
-    const response = await api.get<Location[]>(`/locations?province=${provinceId}`);
+  getLocationsByProvince: async (
+    provinceId: number
+  ): Promise<{ success: boolean; locations: Location[] }> => {
+    const response = await api.get<{
+      success: boolean;
+      locations: Location[];
+    }>(`/locations/province/${provinceId}`);
     return response.data;
   },
 };


### PR DESCRIPTION
## Summary
- adapt tag service to new API response wrapper
- fetch locations by province using updated endpoint
- adjust CreateEventScreen for new location response shape

## Testing
- `npm test` (eventos-app) *(fails: Missing script)*
- `npm test` (api-eventos) *(fails: Error: no test specified)*
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68ac50015f748329b619da3bca0994ef