### PR TITLE
Add pagination to event location listing

### DIFF
--- a/api-eventos/config/db.js
+++ b/api-eventos/config/db.js
@@ -162,13 +162,21 @@ async function findEventLocationById(id) {
   return data;
 }
 
-async function getEventLocationsByUser(userId) {
-  const { data, error } = await supabase
+async function getEventLocationsByUser(userId, page = 1, limit = 10) {
+  let query = supabase
     .from('event_locations')
-    .select('*')
+    .select('*', { count: 'exact' })
     .eq('id_creator_user', userId);
+
+  if (page && limit) {
+    const from = (page - 1) * limit;
+    const to = from + limit - 1;
+    query = query.range(from, to);
+  }
+
+  const { data, count, error } = await query;
   if (error) throw error;
-  return data;
+  return { locations: data, total: count };
 }
 
 async function updateEventLocation(id, updates) {

--- a/api-eventos/controllers/event-location.controller.js
+++ b/api-eventos/controllers/event-location.controller.js
@@ -4,9 +4,11 @@ exports.listEventLocations = async (req, res) => {
   try {
     const userId = req.user && req.user.id;
     if (!userId) throw { status: 401, message: 'No autenticado.' };
+    const page = parseInt(req.query.page) || 1;
+    const limit = parseInt(req.query.limit) || 10;
 
-    const locations = await dbOperations.getEventLocationsByUser(userId);
-    res.json({ collection: locations });
+    const { locations, total } = await dbOperations.getEventLocationsByUser(userId, page, limit);
+    res.json({ page, total, collection: locations });
   } catch (err) {
     console.error('Error en listEventLocations:', err);
     res.status(err.status || 400).json({ message: err.message || 'Error al listar event-locations.' });


### PR DESCRIPTION
## Summary
- support `page` and `limit` query parameters for listing event locations
- paginate `getEventLocationsByUser` with total count and range support
- respond with pagination metadata in event location list endpoint

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68ac5001fa548329a429078606b94cfc