### PR TITLE
refactor: avoid static import for ToastAndroid

### DIFF
--- a/eventos-app/src/screens/RegisterScreen.tsx
+++ b/eventos-app/src/screens/RegisterScreen.tsx
@@ -58,10 +58,10 @@ const RegisterScreen: React.FC<{ navigation: any }> = ({ navigation }) => {
 
   const showSuccessMessage = () => {
     if (Platform.OS === 'android') {
-      const { ToastAndroid } = require('react-native');
-      ToastAndroid.show(
+      const rn = require('react-native');
+      rn.ToastAndroid?.show(
         'Registro exitoso. Ahora puedes iniciar sesión.',
-        ToastAndroid.SHORT
+        rn.ToastAndroid.SHORT
       );
     } else {
       Alert.alert(


### PR DESCRIPTION
## Summary
- use runtime `require` in RegisterScreen to safely access `ToastAndroid`

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68ac7744a0148329b43fd9dcca1e1195